### PR TITLE
Install x509-types directory (#11)

### DIFF
--- a/Formula/easy-rsa.rb
+++ b/Formula/easy-rsa.rb
@@ -28,6 +28,7 @@ class EasyRsa < Formula
       easyrsa3/easyrsa
       easyrsa3/openssl-1.0.cnf
       easyrsa3/vars.example
+      easyrsa3/x509-types
     )
 
     doc.install "ChangeLog"


### PR DESCRIPTION
This fixes the `easyrsa build-server-full` command, which previously failed because the X509 type definitions were missing.