### PR TITLE
Remove openssl dependency

### DIFF
--- a/Formula/easy-rsa.rb
+++ b/Formula/easy-rsa.rb
@@ -5,8 +5,6 @@ class EasyRsa < Formula
   sha256 "01d0a0b0105fb80742455cef8b6336fcb67bf69c8675d3bbd66fdf741fd6d34f"
   head "https://github.com/OpenVPN/easy-rsa.git"
 
-  depends_on "openssl"
-
   devel do
     version '3.0.4'
   end
@@ -16,17 +14,9 @@ class EasyRsa < Formula
               "#set_var EASYRSA\t\"${0%/*}\"",
               "#set_var EASYRSA \"#{Formula["easy-rsa"].opt_prefix}/share\""    
 
-    inreplace "easyrsa3/vars.example",
-              "#set_var EASYRSA_OPENSSL\t\"openssl\"",
-              "#set_var EASYRSA_OPENSSL \"#{Formula["openssl"].opt_prefix}/bin/openssl\""
-
     inreplace "easyrsa3/easyrsa",
               "set_var EASYRSA\t\t\"${0%/*}\"",
               "set_var EASYRSA \"#{Formula["easy-rsa"].opt_prefix}/share\""
-
-    inreplace "easyrsa3/easyrsa",
-              "set_var EASYRSA_OPENSSL\topenssl",
-              "set_var EASYRSA_OPENSSL \"#{Formula["openssl"].opt_prefix}/bin/openssl\""
 
     inreplace "easyrsa3/easyrsa",
               "\tprog_vars=\"${0%/*}/vars\"",


### PR DESCRIPTION
easy-rsa 3.0.5 supports LibreSSL.

This PR removes OpenSSL dependency.

LibreSSL is much slower than OpenSSL though:

`> echo "test" | time easyrsa build-ca nopass`

```
LibreSSL:
easyrsa build-ca nopass  9.03s user 0.03s system 99% cpu 9.073 total
OpenSSL:
easyrsa build-ca nopass  0.47s user 0.02s system 98% cpu 0.493 total
```